### PR TITLE
注文口遷移のトランジション追加

### DIFF
--- a/src/components/RotatedMenuArea.tsx
+++ b/src/components/RotatedMenuArea.tsx
@@ -19,10 +19,12 @@ const RotatedMenuArea: React.FC<RotatedMenuAreaProps> = ({
 }) => {
   const [isRotated, setIsRotated] = useState(false);
 
-  // 商品が選択された時に回転
+  // 商品が選択された時に回転、選択解除時にリセット
   useEffect(() => {
     if (selectedItem) {
       setIsRotated(true);
+    } else {
+      setIsRotated(false);
     }
   }, [selectedItem]);
 

--- a/src/components/orderPage.tsx
+++ b/src/components/orderPage.tsx
@@ -70,7 +70,9 @@ const OrderPage: React.FC<OrderPageProps> = ({
           transition: 'opacity 300ms ease-in-out',
         }}
       >
-        {displayContent.view === 'title' && <TitleScreen onStartOrder={handleStartOrder} />}
+        {displayContent.view === 'title' && (
+          <TitleScreen onStartOrder={handleStartOrder} />
+        )}
 
         {displayContent.view === 'menu' && (
           <MenuList
@@ -84,7 +86,10 @@ const OrderPage: React.FC<OrderPageProps> = ({
         )}
 
         {displayContent.view === 'receipt' && (
-          <OrderReceipt order={displayContent.currentOrder} onBackToMenu={handleBackToMenu} />
+          <OrderReceipt
+            order={displayContent.currentOrder}
+            onBackToMenu={handleBackToMenu}
+          />
         )}
       </main>
 

--- a/src/components/orderPage.tsx
+++ b/src/components/orderPage.tsx
@@ -56,7 +56,7 @@ const OrderPage: React.FC<OrderPageProps> = ({
       // For view changes without counter changes, update immediately
       setDisplayContent({ view, currentOrder, currentOrderCounter });
     }
-  }, [view, currentOrder, currentOrderCounter, displayContent]);
+  }, [view, currentOrder, currentOrderCounter]);
 
   return (
     <div>

--- a/src/components/orderPage.tsx
+++ b/src/components/orderPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Header from './Header';
 import Footer from './Footer';
 import TitleScreen from './TitleScreen';
@@ -40,11 +40,13 @@ const OrderPage: React.FC<OrderPageProps> = ({
     currentOrder,
     currentOrderCounter,
   });
+  const prevCounterRef = useRef(currentOrderCounter);
 
   useEffect(() => {
     // Only trigger fade transition when currentOrderCounter changes (not view changes)
-    if (displayContent.currentOrderCounter !== currentOrderCounter) {
+    if (prevCounterRef.current !== currentOrderCounter) {
       setIsTransitioning(true);
+      prevCounterRef.current = currentOrderCounter;
 
       const transitionTimer = setTimeout(() => {
         setDisplayContent({ view, currentOrder, currentOrderCounter });

--- a/src/components/orderPage.tsx
+++ b/src/components/orderPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Header from './Header';
 import Footer from './Footer';
 import TitleScreen from './TitleScreen';
@@ -20,7 +20,7 @@ interface OrderPageProps {
   handleForceReturnToZero: () => void;
 }
 
-const orderPage: React.FC<OrderPageProps> = ({
+const OrderPage: React.FC<OrderPageProps> = ({
   exitNumber,
   size = 'medium',
   view,
@@ -34,6 +34,30 @@ const orderPage: React.FC<OrderPageProps> = ({
   handleMoveToPreviousCounter,
   handleForceReturnToZero,
 }) => {
+  const [isTransitioning, setIsTransitioning] = useState<boolean>(false);
+  const [displayContent, setDisplayContent] = useState({
+    view,
+    currentOrder,
+    currentOrderCounter,
+  });
+
+  useEffect(() => {
+    // Only trigger fade transition when currentOrderCounter changes (not view changes)
+    if (displayContent.currentOrderCounter !== currentOrderCounter) {
+      setIsTransitioning(true);
+
+      const transitionTimer = setTimeout(() => {
+        setDisplayContent({ view, currentOrder, currentOrderCounter });
+        setIsTransitioning(false);
+      }, 300);
+
+      return () => clearTimeout(transitionTimer);
+    } else {
+      // For view changes without counter changes, update immediately
+      setDisplayContent({ view, currentOrder, currentOrderCounter });
+    }
+  }, [view, currentOrder, currentOrderCounter, displayContent]);
+
   return (
     <div>
       <Header />
@@ -42,23 +66,25 @@ const orderPage: React.FC<OrderPageProps> = ({
         style={{
           minHeight: 'calc(100vh - 100px)',
           backgroundColor: 'var(--bg-dark)',
+          opacity: isTransitioning ? 0 : 1,
+          transition: 'opacity 300ms ease-in-out',
         }}
       >
-        {view === 'title' && <TitleScreen onStartOrder={handleStartOrder} />}
+        {displayContent.view === 'title' && <TitleScreen onStartOrder={handleStartOrder} />}
 
-        {view === 'menu' && (
+        {displayContent.view === 'menu' && (
           <MenuList
             onOrderCreate={handleOrderCreate}
             onBackToPreviousExit={handleBackToPreviousExit}
-            currentOrderCounter={currentOrderCounter}
+            currentOrderCounter={displayContent.currentOrderCounter}
             onMoveToNextCounter={handleMoveToNextCounter}
             onMoveToPreviousCounter={handleMoveToPreviousCounter}
             onForceReturnToZero={handleForceReturnToZero}
           />
         )}
 
-        {view === 'receipt' && (
-          <OrderReceipt order={currentOrder} onBackToMenu={handleBackToMenu} />
+        {displayContent.view === 'receipt' && (
+          <OrderReceipt order={displayContent.currentOrder} onBackToMenu={handleBackToMenu} />
         )}
       </main>
 
@@ -67,4 +93,4 @@ const orderPage: React.FC<OrderPageProps> = ({
   );
 };
 
-export default orderPage;
+export default OrderPage;


### PR DESCRIPTION
## やったこと
注文口を移動したとき（`currentOrderCounter`の値が変更されたとき）トランジションをかけるようにした
useEffectの依存配列に対するeslintのエラーを解消するため、useRefを用いてメモ化し、依存配列に含まないようにしてある

あと、180度回転する異変を連続で引くと、２回目以降が初期状態が回転した状態になってしまう現象を、初期値を明示的にセットすることで解消した。