### PR TITLE
レシート自動ダウンロード機能追加

### DIFF
--- a/src/components/BaseMenuArea.test.tsx
+++ b/src/components/BaseMenuArea.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BaseMenuArea from './BaseMenuArea';
+
+const mockMenu = [
+  {
+    id: '1',
+    name: 'いちごかき氷',
+    description: '甘くて美味しいいちご味',
+  },
+  {
+    id: '2',
+    name: 'メロンかき氷',
+    description: 'さっぱりとしたメロン味',
+  },
+];
+
+const defaultProps = {
+  menu: mockMenu,
+  selectedItem: null,
+  onItemSelect: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders menu items correctly', () => {
+  render(<BaseMenuArea {...defaultProps} />);
+
+  expect(screen.getByText('いちごかき氷')).toBeInTheDocument();
+  expect(screen.getByText('甘くて美味しいいちご味')).toBeInTheDocument();
+  expect(screen.getByText('メロンかき氷')).toBeInTheDocument();
+  expect(screen.getByText('さっぱりとしたメロン味')).toBeInTheDocument();
+});
+
+test('renders item numbers correctly', () => {
+  render(<BaseMenuArea {...defaultProps} />);
+
+  expect(screen.getByText('1')).toBeInTheDocument();
+  expect(screen.getByText('2')).toBeInTheDocument();
+});
+
+test('calls onItemSelect when item is clicked', () => {
+  const mockOnItemSelect = jest.fn();
+  render(<BaseMenuArea {...defaultProps} onItemSelect={mockOnItemSelect} />);
+
+  const firstItem = screen.getByText('いちごかき氷');
+  fireEvent.click(firstItem);
+
+  expect(mockOnItemSelect).toHaveBeenCalledWith(mockMenu[0]);
+});
+
+test('applies selected styles to selected item', () => {
+  const selectedItem = mockMenu[0];
+  render(<BaseMenuArea {...defaultProps} selectedItem={selectedItem} />);
+
+  const selectedItemElement = screen.getByText('いちごかき氷').closest('div');
+  expect(selectedItemElement).toHaveStyle(
+    'border: 2px solid var(--accent-yellow)'
+  );
+});
+
+test('applies default styles to unselected items', () => {
+  const selectedItem = mockMenu[0];
+  render(<BaseMenuArea {...defaultProps} selectedItem={selectedItem} />);
+
+  const unselectedItemElement = screen.getByText('メロンかき氷').closest('div');
+  expect(unselectedItemElement).toHaveStyle(
+    'border: 1px solid var(--border-gray)'
+  );
+  expect(unselectedItemElement).not.toHaveClass('fluorescent-light');
+});
+
+test('applies responsive font sizes', () => {
+  render(<BaseMenuArea {...defaultProps} />);
+
+  const menuNameElement = screen.getByText('いちごかき氷');
+  const menuDescElement = screen.getByText('甘くて美味しいいちご味');
+
+  // 要素が存在することを確認（フォントサイズはCSSで制御されている）
+  expect(menuNameElement).toBeInTheDocument();
+  expect(menuDescElement).toBeInTheDocument();
+});
+
+test('applies responsive sizing to item numbers', () => {
+  render(<BaseMenuArea {...defaultProps} />);
+
+  const numberElement = screen.getByText('1');
+  const numberContainer = numberElement.parentElement;
+
+  expect(numberContainer).toHaveStyle('width: clamp(35px, 8vw, 45px)');
+  expect(numberContainer).toHaveStyle('height: clamp(35px, 8vw, 45px)');
+  expect(numberElement).toHaveStyle('font-size: clamp(0.8rem, 3vw, 1.1rem)');
+});
+
+test('renders custom content when renderItemContent is provided', () => {
+  const customRenderItemContent = (item: any, index: number) => ({
+    name: `カスタム${item.name}`,
+    description: `カスタム${item.description}`,
+  });
+
+  render(
+    <BaseMenuArea
+      {...defaultProps}
+      renderItemContent={customRenderItemContent}
+    />
+  );
+
+  expect(screen.getByText('カスタムいちごかき氷')).toBeInTheDocument();
+  expect(
+    screen.getByText('カスタム甘くて美味しいいちご味')
+  ).toBeInTheDocument();
+});
+
+test('applies custom className and containerStyle', () => {
+  const customStyle = { backgroundColor: 'red' };
+  const { container } = render(
+    <BaseMenuArea
+      {...defaultProps}
+      className="custom-class"
+      containerStyle={customStyle}
+    />
+  );
+
+  const menuAreaElement = container.querySelector('.exit-sign.custom-class');
+  expect(menuAreaElement).toBeInTheDocument();
+  expect(menuAreaElement).toHaveStyle('background-color: red');
+});
+
+test('renders children when provided', () => {
+  render(
+    <BaseMenuArea {...defaultProps}>
+      <div>カスタム子要素</div>
+    </BaseMenuArea>
+  );
+
+  expect(screen.getByText('カスタム子要素')).toBeInTheDocument();
+});
+
+test('handles empty menu array', () => {
+  render(<BaseMenuArea {...defaultProps} menu={[]} />);
+
+  expect(screen.queryByText('1')).not.toBeInTheDocument();
+  expect(screen.queryByText('いちごかき氷')).not.toBeInTheDocument();
+});

--- a/src/components/BaseMenuArea.tsx
+++ b/src/components/BaseMenuArea.tsx
@@ -70,8 +70,8 @@ const BaseMenuArea: React.FC<BaseMenuAreaProps> = ({
               {/* 路線図風の番号 */}
               <div
                 style={{
-                  width: '40px',
-                  height: '40px',
+                  width: 'clamp(35px, 8vw, 45px)',
+                  height: 'clamp(35px, 8vw, 45px)',
                   borderRadius: '50%',
                   backgroundColor: isSelected
                     ? 'var(--accent-yellow)'
@@ -81,7 +81,7 @@ const BaseMenuArea: React.FC<BaseMenuAreaProps> = ({
                   alignItems: 'center',
                   justifyContent: 'center',
                   fontWeight: 'bold',
-                  fontSize: '1rem',
+                  fontSize: 'clamp(0.8rem, 3vw, 1.1rem)',
                   flexShrink: 0,
                 }}
               >
@@ -93,7 +93,7 @@ const BaseMenuArea: React.FC<BaseMenuAreaProps> = ({
                   style={{
                     margin: '0 0 8px 0',
                     color: 'var(--text-light)',
-                    fontSize: '1.2rem',
+                    fontSize: 'clamp(1.1rem, 4.5vw, 1.5rem)',
                     fontWeight: 'bold',
                   }}
                 >
@@ -103,7 +103,7 @@ const BaseMenuArea: React.FC<BaseMenuAreaProps> = ({
                   style={{
                     margin: '0',
                     color: 'var(--text-dim)',
-                    fontSize: '0.9rem',
+                    fontSize: 'clamp(0.8rem, 3vw, 1rem)',
                     lineHeight: '1.4',
                   }}
                 >

--- a/src/components/MenuList.test.tsx
+++ b/src/components/MenuList.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import MenuList from './MenuList';
+import { kakigoriApi } from '../api/client';
+
+// Mock the API
+jest.mock('../api/client', () => ({
+  kakigoriApi: {
+    getMenu: jest.fn(),
+    createOrder: jest.fn(),
+  },
+}));
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: { [key: string]: string } = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+// Mock window.scrollTo
+Object.defineProperty(window, 'scrollTo', {
+  value: jest.fn(),
+});
+
+const mockMenu = [
+  {
+    id: '1',
+    name: 'いちご かき氷',
+    description: '甘くて美味しい いちご味',
+  },
+  {
+    id: '2',
+    name: 'メロン かき氷 特大',
+    description: 'さっぱりとした メロン味',
+  },
+];
+
+const defaultProps = {
+  onOrderCreate: jest.fn(),
+  onBackToPreviousExit: jest.fn(),
+  currentOrderCounter: 0,
+  onMoveToNextCounter: jest.fn(),
+  onMoveToPreviousCounter: jest.fn(),
+  onForceReturnToZero: jest.fn(),
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.clearAllMocks();
+  (kakigoriApi.getMenu as jest.Mock).mockResolvedValue({ menu: mockMenu });
+});
+
+test('renders loading state initially', () => {
+  render(<MenuList {...defaultProps} />);
+  expect(screen.getByText('メニューを読み込み中...')).toBeInTheDocument();
+});
+
+test('renders menu items after loading', async () => {
+  render(<MenuList {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('いちごかき氷')).toBeInTheDocument();
+    expect(screen.getByText('メロンかき氷特大')).toBeInTheDocument();
+  });
+});
+
+test('removes spaces from menu item names', async () => {
+  render(<MenuList {...defaultProps} />);
+
+  await waitFor(() => {
+    // スペースが削除されていることを確認
+    expect(screen.getByText('いちごかき氷')).toBeInTheDocument();
+    expect(screen.getByText('メロンかき氷特大')).toBeInTheDocument();
+    // スペース付きの名前は存在しないことを確認
+    expect(screen.queryByText('いちご かき氷')).not.toBeInTheDocument();
+    expect(screen.queryByText('メロン かき氷 特大')).not.toBeInTheDocument();
+  });
+});
+
+test('renders menu item descriptions with original spacing', async () => {
+  render(<MenuList {...defaultProps} />);
+
+  await waitFor(() => {
+    // 説明文は元のスペースが保持されていることを確認
+    expect(screen.getByText('甘くて美味しい いちご味')).toBeInTheDocument();
+    expect(screen.getByText('さっぱりとした メロン味')).toBeInTheDocument();
+  });
+});
+
+test('enables order button when item is selected', async () => {
+  render(<MenuList {...defaultProps} />);
+
+  await waitFor(() => {
+    const orderButton = screen.getByText('注文する');
+    expect(orderButton).toBeDisabled();
+
+    const menuItem = screen.getByText('いちごかき氷');
+    fireEvent.click(menuItem);
+
+    expect(orderButton).not.toBeDisabled();
+  });
+});
+
+test('displays error when API fails', async () => {
+  (kakigoriApi.getMenu as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+  render(<MenuList {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('エラー: API Error')).toBeInTheDocument();
+  });
+});
+
+test('disables back button at counter 0', async () => {
+  render(<MenuList {...defaultProps} currentOrderCounter={0} />);
+
+  await waitFor(() => {
+    const backButton = screen.getByText('引き返す');
+    expect(backButton).toBeDisabled();
+  });
+});
+
+test('enables back button at counter other than 0', async () => {
+  render(<MenuList {...defaultProps} currentOrderCounter={1} />);
+
+  await waitFor(() => {
+    const backButton = screen.getByText('引き返す');
+    expect(backButton).not.toBeDisabled();
+  });
+});

--- a/src/components/MenuList.tsx
+++ b/src/components/MenuList.tsx
@@ -171,7 +171,11 @@ const MenuList: React.FC<MenuListProps> = ({
       try {
         setLoading(true);
         const response = await kakigoriApi.getMenu();
-        setMenu(response.menu);
+        const menuWithNoSpaces = response.menu.map((item: MenuItem) => ({
+          ...item,
+          name: item.name.replace(/\s+/g, '')
+        }));
+        setMenu(menuWithNoSpaces);
       } catch (err) {
         setError((err as Error).message);
       } finally {

--- a/src/components/MenuList.tsx
+++ b/src/components/MenuList.tsx
@@ -173,7 +173,7 @@ const MenuList: React.FC<MenuListProps> = ({
         const response = await kakigoriApi.getMenu();
         const menuWithNoSpaces = response.menu.map((item: MenuItem) => ({
           ...item,
-          name: item.name.replace(/\s+/g, '')
+          name: item.name.replace(/\s+/g, ''),
         }));
         setMenu(menuWithNoSpaces);
       } catch (err) {

--- a/src/components/OrderReceipt.tsx
+++ b/src/components/OrderReceipt.tsx
@@ -286,7 +286,6 @@ Thank you for your order!
             STATUS: {order.status.toUpperCase()}
           </div>
         </div>
-
       </div>
     </div>
   );

--- a/src/components/OrderReceipt.tsx
+++ b/src/components/OrderReceipt.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 const getStatusText = (status: string) => {
   switch (status) {
@@ -40,6 +40,40 @@ interface OrderReceiptProps {
 }
 
 const OrderReceipt: React.FC<OrderReceiptProps> = ({ order, onBackToMenu }) => {
+  useEffect(() => {
+    if (!order) return;
+
+    const receiptText = `
+===========================================
+        ORDER RECEIPT
+===========================================
+
+ORDER NUMBER: #${order.order_number}
+MENU NAME: ${order.menu_name}
+STATUS: ${getStatusText(order.status)}
+
+-------------------------------------------
+DETAILS:
+ORDER ID: ${order.id}
+MENU ID: ${order.menu_item_id}
+DATE: ${new Date().toLocaleString('ja-JP')}
+
+-------------------------------------------
+Thank you for your order!
+===========================================
+    `.trim();
+
+    const blob = new Blob([receiptText], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `order_${order.order_number}_receipt.txt`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [order]);
+
   if (!order) {
     return (
       <div
@@ -174,9 +208,15 @@ const OrderReceipt: React.FC<OrderReceiptProps> = ({ order, onBackToMenu }) => {
               color: 'var(--text-light)',
               fontSize: '1.5rem',
               letterSpacing: '1px',
+              lineHeight: '1.6',
             }}
           >
-            {order.menu_name}
+            {order.menu_name.split(' ').map((word, index) => (
+              <span key={index}>
+                {word}
+                {index < order.menu_name.split(' ').length - 1 && <br />}
+              </span>
+            ))}
           </h3>
           <div
             style={{
@@ -246,6 +286,7 @@ const OrderReceipt: React.FC<OrderReceiptProps> = ({ order, onBackToMenu }) => {
             STATUS: {order.status.toUpperCase()}
           </div>
         </div>
+
       </div>
     </div>
   );


### PR DESCRIPTION
## やったこと

購入番号等が表示されるレシート画面に遷移した際に、自動的に添付写真のようなレシートがダウンロードされるようにした。
これにより、勝手にダウンロードするやばいUIと購入番号がわからなくなるといった事象を対策することができる
<img width="377" height="364" alt="スクリーンショット 2025-09-22 213359" src="https://github.com/user-attachments/assets/7f1aaad7-6180-4a55-b190-196491dcc512" />
