### PR TITLE
重複してレシートが発行されるバグを修正

### DIFF
--- a/src/components/OrderReceipt.tsx
+++ b/src/components/OrderReceipt.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const getStatusText = (status: string) => {
   switch (status) {
@@ -40,8 +40,12 @@ interface OrderReceiptProps {
 }
 
 const OrderReceipt: React.FC<OrderReceiptProps> = ({ order, onBackToMenu }) => {
+  const downloadedRef = useRef(false);
+
   useEffect(() => {
-    if (!order) return;
+    if (!order || downloadedRef.current) return;
+
+    downloadedRef.current = true;
 
     const receiptText = `
 ===========================================


### PR DESCRIPTION
## やったこと
useEffectを用いた処理だったので、reactのstrictモードによる重複実行がされていた可能性を考慮し、useRefを用いた方式に変えた。